### PR TITLE
Add `parseAll()` method and correctness-checking of strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,17 @@ class Subsume {
 		if (ids && typeof ids[Symbol.iterator] !== 'function') {
 			throw new Error('ids is supposed to be an iterable');
 		}
-		const data = [];
+		const data = {data: new Map(), rest: str}; 
 
 		const idList = ids ? ids : Subsume.extractIDs(str);
 
 		idList.forEach(id => {
-			data[id] = Subsume.parse(str, id);
+			if(data.data.get(id)){
+				throw new Error("IDs aren't supposed to be repeated at the same level in a string");
+			}
+			let res = Subsume.parse(data.rest, id);
+			data.data.set(id, res.data);
+			data.rest = res.rest;
 		});
 
 		return data;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ class Subsume {
 	}
 
 	static parseAll(str, ids) {
-		if (ids && ids.constructor !== Array) {
+		if (ids && !Array.isArray(ids)) {
 			throw new TypeError('IDs is supposed to be an array');
 		}
 		const result = {data: new Map(), rest: str};
@@ -40,21 +40,22 @@ class Subsume {
 		} catch (err) {
 			throw new Error(`Could not extract IDs because the string's integrity is compromised: ${err.message}`);
 		}
-		const idRegex = /@@\[(.{32})\]@@.*##\[(\1)\]##/g;
+		const idRegex = /@@\[(.{32})\]@@.*##\[\1\]##/g;
 		const idList = [];
 		let match;
 
 		do {
 			match = idRegex.exec(str);
-			if (match && match[1] === match[2]) {
-				idList.push(match[1]);
+			if (match) {
+				const [, id] = match;
+				idList.push(id);
 			}
 		} while (match);
 		return idList;
 	}
 
 	static _checkIntegrity(str) {
-		const delimiterRegex = /([#|@])(?:\1)\[(.{32})\](?:\1){2}/g;
+		const delimiterRegex = /([#|@])\1\[(.{32})\]\1{2}/g;
 		const ids = new Map();
 		const idStack = [];
 		let match;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,38 @@ class Subsume {
 	static parse(str, id) {
 		return (new Subsume(id)).parse(str);
 	}
+
+	static parseAll(str, ids) {
+		if (ids && typeof ids[Symbol.iterator] !== 'function') {
+			throw new Error('ids is supposed to be an iterable');
+		}
+		const data = [];
+
+		const idList = ids ? ids : Subsume.extractIDs(str);
+
+		idList.forEach(id => {
+			data[id] = Subsume.parse(str, id);
+		});
+
+		return data;
+	}
+
+	static extractIDs(str) {
+		// Ideally the regex would be '@@\[(.{32})]@@(.*?)##\[\1\]##', but strict mode doesn't allow for octal escape sequences
+		const idRegex = new RegExp('@@\\[(.{32})\\]@@.*?##\\[(.{32})\\]##', 'g');
+		const idList = [];
+		let match;
+
+		do {
+			match = idRegex.exec(str);
+			if (match && match[1] === match[2]) {
+				idList.push(match[1]);
+			}
+		} while (match);
+
+		return idList;
+	}
+
 	constructor(id) {
 		if (id && (id.includes('@@[') || id.includes('##['))) {
 			throw new Error('`@@[` and `##[` cannot be used in the ID');
@@ -16,9 +48,11 @@ class Subsume {
 		this.postfix = `##[${this.id}]##`;
 		this.regex = new RegExp(escapeStringRegexp(this.prefix) + '([\\S\\s]*)' + escapeStringRegexp(this.postfix), 'g');
 	}
+
 	compose(str) {
 		return this.prefix + str + this.postfix;
 	}
+
 	parse(str) {
 		const ret = {};
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,24 @@ Useful when `text` comes from an external source.
 
 Extract embedded data corresponding to all ids in `idArray`, if specified. Otherwise it will extract embedded data for all top-level ids.
 
-Returns an object with properties `.data`, a Map with an entry for each parsed id, and `.rest` for what remains after all the required ids have been parsed.
+Returns an object with properties `.data`, a Map with an entry for each parsed id, and `.rest` for what remains after all the required ids have been parsed, as seen below:
+
+The input:
+
+```
+some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random@@[7febcd0b3806fbc48c01d7cea4ed1218]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1218]## text@@[7febcd0b3806fbc48c01d7cea4ed1217]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1217]##
+```
+
+Gives the followinf output:
+
+```
+{ data:
+   Map {
+     '7febcd0b3806fbc48c01d7cea4ed1219' => '🦄',
+     '7febcd0b3806fbc48c01d7cea4ed1218' => '🦄',
+     '7febcd0b3806fbc48c01d7cea4ed1217' => '🦄' },
+  rest: 'some random text' }
+```
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,11 @@ Extract embedded data with a specific `id` out of `text`.
 
 Useful when `text` comes from an external source.
 
+### Subsume.parseAll(text[, idArray])
+
+Extract embedded data corresponding to all ids in `idArray`, if specified. Otherwise it will extract embedded data for all top-level ids.
+
+Returns an object with properties `.data`, a Map with an entry for each parsed id, and `.rest` for what remains after all the required ids have been parsed.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -51,15 +51,21 @@ test('Subsume#checkIntegrity()', t => {
 	const fixture3 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random @@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]##text';
 	const fixture4 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random @@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄text';
 
-	t.deepEqual(Subsume.checkIntegrity(fixture1), {'7febcd0b3806fbc48c01d7cea4ed1219': {}});
-	t.deepEqual(Subsume.checkIntegrity(fixture2), {'7febcd0b3806fbc48c01d7cea4ed1219': {'7febcd0b3806fbc48c01d7cea4ed1219': {}}});
-	t.throws(() => Subsume.checkIntegrity(fixture3));
-	t.throws(() => Subsume.checkIntegrity(fixture4));
+	const map = new Map();
+	map.set('7febcd0b3806fbc48c01d7cea4ed1219', new Map());
+
+	t.deepEqual(Subsume._checkIntegrity(fixture1), map);
+
+	map.get('7febcd0b3806fbc48c01d7cea4ed1219').set('7febcd0b3806fbc48c01d7cea4ed1219', new Map());
+	t.deepEqual(Subsume._checkIntegrity(fixture2), map);
+
+	t.throws(() => Subsume._checkIntegrity(fixture3));
+	t.throws(() => Subsume._checkIntegrity(fixture4));
 });
 
 test('Subsume#extractIDs()', t => {
 	const fixture = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]####[7febcd0b3806fbc48c01d7cea4ed1219]## random@@[7febcd0b3806fbc48c01d7cea4ed1218]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1218]## text@@[7febcd0b3806fbc48c01d7cea4ed1217]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1217]##';
-	t.deepEqual(Subsume.extractIDs(fixture), ['7febcd0b3806fbc48c01d7cea4ed1219', '7febcd0b3806fbc48c01d7cea4ed1218', '7febcd0b3806fbc48c01d7cea4ed1217']);
+	t.deepEqual(Subsume._extractIDs(fixture), ['7febcd0b3806fbc48c01d7cea4ed1219', '7febcd0b3806fbc48c01d7cea4ed1218', '7febcd0b3806fbc48c01d7cea4ed1217']);
 });
 
 test('Subsume#parseAll()', t => {

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ test('Subsume#parse()', t => {
 	});
 });
 
-test('Subsume#checkIntegrity()', t => {
+test('Subsume#_checkIntegrity()', t => {
 	const fixture1 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random text';
 	const fixture2 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]####[7febcd0b3806fbc48c01d7cea4ed1219]## random text';
 	const fixture3 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random @@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]##text';
@@ -63,7 +63,7 @@ test('Subsume#checkIntegrity()', t => {
 	t.throws(() => Subsume._checkIntegrity(fixture4));
 });
 
-test('Subsume#extractIDs()', t => {
+test('Subsume#_extractIDs()', t => {
 	const fixture = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]####[7febcd0b3806fbc48c01d7cea4ed1219]## random@@[7febcd0b3806fbc48c01d7cea4ed1218]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1218]## text@@[7febcd0b3806fbc48c01d7cea4ed1217]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1217]##';
 	t.deepEqual(Subsume._extractIDs(fixture), ['7febcd0b3806fbc48c01d7cea4ed1219', '7febcd0b3806fbc48c01d7cea4ed1218', '7febcd0b3806fbc48c01d7cea4ed1217']);
 });

--- a/test.js
+++ b/test.js
@@ -44,3 +44,33 @@ test('Subsume#parse()', t => {
 		rest: 'some random text'
 	});
 });
+
+test('Subsume#checkIntegrity()', t => {
+	const fixture1 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random text';
+	const fixture2 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]####[7febcd0b3806fbc48c01d7cea4ed1219]## random text';
+	const fixture3 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random @@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]##text';
+	const fixture4 = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]## random @@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄text';
+
+	t.deepEqual(Subsume.checkIntegrity(fixture1), {'7febcd0b3806fbc48c01d7cea4ed1219': {}});
+	t.deepEqual(Subsume.checkIntegrity(fixture2), {'7febcd0b3806fbc48c01d7cea4ed1219': {'7febcd0b3806fbc48c01d7cea4ed1219': {}}});
+	t.throws(() => Subsume.checkIntegrity(fixture3));
+	t.throws(() => Subsume.checkIntegrity(fixture4));
+});
+
+test('Subsume#extractIDs()', t => {
+	const fixture = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]####[7febcd0b3806fbc48c01d7cea4ed1219]## random@@[7febcd0b3806fbc48c01d7cea4ed1218]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1218]## text@@[7febcd0b3806fbc48c01d7cea4ed1217]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1217]##';
+	t.deepEqual(Subsume.extractIDs(fixture), ['7febcd0b3806fbc48c01d7cea4ed1219', '7febcd0b3806fbc48c01d7cea4ed1218', '7febcd0b3806fbc48c01d7cea4ed1217']);
+});
+
+test('Subsume#parseAll()', t => {
+	const map = new Map();
+	map.set('7febcd0b3806fbc48c01d7cea4ed1219', '🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]##');
+	map.set('7febcd0b3806fbc48c01d7cea4ed1218', '🦄');
+	map.set('7febcd0b3806fbc48c01d7cea4ed1217', '🦄');
+
+	const fixture = 'some@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄@@[7febcd0b3806fbc48c01d7cea4ed1219]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1219]####[7febcd0b3806fbc48c01d7cea4ed1219]## random@@[7febcd0b3806fbc48c01d7cea4ed1218]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1218]## text@@[7febcd0b3806fbc48c01d7cea4ed1217]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1217]##';
+	t.deepEqual(Subsume.parseAll(fixture), {data: map, rest: 'some random text'});
+
+	map.delete('7febcd0b3806fbc48c01d7cea4ed1217');
+	t.deepEqual(Subsume.parseAll(fixture, ['7febcd0b3806fbc48c01d7cea4ed1219', '7febcd0b3806fbc48c01d7cea4ed1218']), {data: map, rest: 'some random text@@[7febcd0b3806fbc48c01d7cea4ed1217]@@🦄##[7febcd0b3806fbc48c01d7cea4ed1217]##'});
+});


### PR DESCRIPTION
This PR resolves #1 as well as fixes #2. 

A new method parseAll is added which allows one to retrieve all embeded data or the data with the provided IDs. An auxiliary method was also added, extractIDs, in order to be able to know which IDs to parse.

Now, in the functions where strings are manipulated, the integrity-checking function is called to ascertain whether the string is safe to use (i. e whether it will give the expected output).